### PR TITLE
Windows error

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -23,3 +23,5 @@ supports 'redhat'
 supports 'centos', '~> 6.5'
 supports 'amazon', '~> 2015.09'
 supports 'windows'
+
+depends 'windows'

--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -1,0 +1,115 @@
+#
+# Cookbook Name:: aws-inspector
+# Recipe:: default
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 eternaltyro
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+##
+# Remove the AWS inspector package from the system if it's already
+# installed
+#
+package 'awsagent' do
+  case node[:platform]
+  when 'redhat', 'centos', 'amazon'
+    package_name 'AwsAgent'
+  when 'debian', 'ubuntu'
+    package_name 'awsagent'
+  end
+  action   :remove
+  notifies :stop, 'service[awsagent]', :immediately
+  not_if   { node[:inspector][:enabled] }
+end
+
+package 'gnupg2' do # Used for cryptographic verification later on
+  action :install
+  not_if { platform?('windows') }
+end
+
+##
+# Download and GPG verification key for AWS inspector binary
+#
+remote_file "#{Chef::Config[:file_cache_path]}/inspector.gpg" do
+  source              node[:inspector][:gpgkey_url]
+  use_conditional_get true
+  mode                0440
+  action              :create
+  only_if             { node[:inspector][:enabled] }
+  not_if              { platform?('windows') }
+  notifies            :run, 'execute[import_key]', :immediately
+end
+
+##
+# ...and import it, pronto!
+#
+execute 'import_key' do
+  command "gpg2 --import #{Chef::Config[:file_cache_path]}/inspector.gpg"
+  action :nothing
+  not_if { platform?('windows') }
+end
+
+##
+# Download the PGP cryptographic signature for the AWS inspector binary
+#
+remote_file "#{Chef::Config[:file_cache_path]}/install.sig" do
+  source              node.default[:inspector][:gpg_signature_url]
+  use_conditional_get true
+  mode                0o440
+  action              :create_if_missing
+  only_if             { node[:inspector][:enabled] }
+  not_if              { platform?('windows') }
+end
+
+##
+# Download AWS Inspector installer script
+#
+remote_file "#{Chef::Config[:file_cache_path]}/inspector" do
+  source              node.default[:inspector][:installer_url]
+  use_conditional_get true
+  mode                0o440
+  action              :create
+  only_if             { node[:inspector][:enabled] }
+  not_if              { platform?('windows') }
+end
+
+##
+# Install the AWS inspector binary *if* the installer script can be
+# cryptographically verified to be from AWS
+#
+execute 'install-inspector' do
+  command "bash #{Chef::Config[:file_cache_path]}/inspector -u false"
+  only_if "/usr/bin/gpg2 --verify #{Chef::Config[:file_cache_path]}/install.sig #{Chef::Config[:file_cache_path]}/inspector"
+  only_if { node.normal[:inspector][:enabled] }
+  not_if { ::File.exist?('/opt/aws/awsagent/bin/awsagent') }
+  not_if { platform?('windows') }
+  notifies :start, 'service[awsagent]', :immediately
+end
+
+##
+# AWS inspector service
+#
+service 'awsagent' do
+  supports :start => true, :stop => true, :status => true
+  status_command '/opt/aws/awsagent/bin/awsagent status'
+  action :nothing
+  not_if { platform?('windows') }
+end

--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: aws-inspector
-# Recipe:: default
+# Recipe:: linux
 #
 # The MIT License (MIT)
 #

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -24,11 +24,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-case node['os']
-when 'linux'
-  include_recipe 'aws-inspector::linux'
-when 'windows'
-  include_recipe 'aws-inspector::windows'
-else
-  raise
+# Install for Windows
+windows_package 'awsagent' do
+  source node[:inspector][:win_installer_url]
+  installer_type :custom
+  options '-silent'
+  only_if { platform?('windows') }
+end
+
+##
+# AWS inspector service
+#
+windows_service 'AWSAgent' do
+  action [:enable, :start]
+  only_if { platform?('windows') }
+end
+
+windows_service 'AWSAgentUpdater' do  # AWS Agent Updater service for Windows
+  action [:enable, :start]
+  only_if { platform?('windows') }
 end

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: aws-inspector
-# Recipe:: default
+# Recipe:: windows
 #
 # The MIT License (MIT)
 #


### PR DESCRIPTION
This resolves #8 

Run would fail with:
[2018-05-17T13:14:25+00:00] ================================================================================
[2018-05-17T13:14:25+00:00] Recipe Compile Error in /etc/chef/cache/chef/cookbooks/ge_linux-hardening/recipes/default.rb
[2018-05-17T13:14:25+00:00] ================================================================================
[2018-05-17T13:14:25+00:00] 
[2018-05-17T13:14:25+00:00] Chef::Exceptions::NoSuchResourceType
[2018-05-17T13:14:25+00:00] ------------------------------------
[2018-05-17T13:14:25+00:00] Cannot find a resource for windows_package on centos version 7.5.1804
[2018-05-17T13:14:25+00:00] 
[2018-05-17T13:14:25+00:00] Cookbook Trace:
[2018-05-17T13:14:25+00:00] ---------------
[2018-05-17T13:14:25+00:00]   /etc/chef/cache/chef/cookbooks/aws-inspector/recipes/default.rb:108:in `from_file'
[2018-05-17T13:14:25+00:00]   /etc/chef/cache/chef/cookbooks/ge_linux-hardening/recipes/linux_aws.rb:4:in `from_file'
[2018-05-17T13:14:25+00:00]   /etc/chef/cache/chef/cookbooks/ge_linux-hardening/recipes/linux.rb:10:in `from_file'
[2018-05-17T13:14:25+00:00]   /etc/chef/cache/chef/cookbooks/ge_linux-hardening/recipes/default.rb:15:in `from_file'
[2018-05-17T13:14:25+00:00] 
[2018-05-17T13:14:25+00:00] Relevant File Content:
[2018-05-17T13:14:25+00:00] ----------------------
[2018-05-17T13:14:25+00:00] /etc/chef/cache/chef/cookbooks/aws-inspector/recipes/default.rb:
[2018-05-17T13:14:25+00:00] 
[2018-05-17T13:14:25+00:00] 101:    only_if { node.normal[:inspector][:enabled] }
[2018-05-17T13:14:25+00:00] 102:    not_if { ::File.exist?('/opt/aws/awsagent/bin/awsagent') }
[2018-05-17T13:14:25+00:00] 103:    not_if { platform?('windows') }
[2018-05-17T13:14:25+00:00] 104:    notifies :start, 'service[awsagent]', :immediately
[2018-05-17T13:14:25+00:00] 105:  end
[2018-05-17T13:14:25+00:00] 106:  
[2018-05-17T13:14:25+00:00] 107:  # Install for Windows
[2018-05-17T13:14:25+00:00] 108>> windows_package 'awsagent' do
[2018-05-17T13:14:25+00:00] 109:    source node[:inspector][:win_installer_url]
[2018-05-17T13:14:25+00:00] 110:    installer_type :custom
[2018-05-17T13:14:25+00:00] 111:    options '-silent'
[2018-05-17T13:14:25+00:00] 112:    only_if { platform?('windows') }
[2018-05-17T13:14:25+00:00] 113:  end
[2018-05-17T13:14:25+00:00] 114:  
[2018-05-17T13:14:25+00:00] 115:  ##
[2018-05-17T13:14:25+00:00] 116:  # AWS inspector service
[2018-05-17T13:14:25+00:00] 117:  #
[2018-05-17T13:14:25+00:00] 
[2018-05-17T13:14:25+00:00] System Info:
[2018-05-17T13:14:25+00:00] ------------
[2018-05-17T13:14:25+00:00] chef_version=12.22.3
[2018-05-17T13:14:25+00:00] platform=centos
[2018-05-17T13:14:25+00:00] platform_version=7.5.1804
[2018-05-17T13:14:25+00:00] ruby=ruby 2.3.6p384 (2017-12-14 revision 61254) [x86_64-linux]
[2018-05-17T13:14:25+00:00] program_name=chef-client worker: ppid=5202;start=13:14:22;
[2018-05-17T13:14:25+00:00] executable=/opt/chef/bin/chef-client
[2018-05-17T13:14:25+00:00] 
[2018-05-17T13:14:25+00:00] [2018-05-17T13:14:25+00:00] ERROR: Running exception handlers
[2018-05-17T13:14:25+00:00] ERROR: Exception handlers complete
[2018-05-17T13:14:25+00:00] FATAL: Stacktrace dumped to /etc/chef/cache/chef/chef-stacktrace.out
[2018-05-17T13:14:25+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2018-05-17T13:14:25+00:00] ERROR: Cannot find a resource for windows_package on centos version 7.5.1804
[2018-05-17T13:14:25+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)

Split windows and linux code into separate files